### PR TITLE
Fix fetch url for API versioning

### DIFF
--- a/app/src/main/java/me/willermo/dolarpy/FetchCotizacionService.java
+++ b/app/src/main/java/me/willermo/dolarpy/FetchCotizacionService.java
@@ -35,7 +35,7 @@ public class FetchCotizacionService extends IntentService {
         OkHttpClient client = new OkHttpClient();
         client.setConnectTimeout(10, TimeUnit.SECONDS);
         client.setReadTimeout(10,TimeUnit.SECONDS);
-        Request request = new Request.Builder().url("http://dolar.melizeche.com/").build();
+        Request request = new Request.Builder().url("http://dolar.melizeche.com/api/1.0/").build();
         Response response=null;
 
 


### PR DESCRIPTION
Inicialmente no pensé que el webservice se iba a usar por lo que no le di mucha bola, ahora que ya hay app y demas quiero hacer mejor las cosas, voy a agregarle mas funcionalidades al API(calculadora, cotización del bcp, etc) así como también quiero que dolar.melizeche.com sea una landing page explicando los endpoints, por eso el API se mudó a dolar.melizeche.com/api/1.0/ pero tranquilo dolar.melizeche.com va a seguir funcionando correctamente hasta que me des el OK que la app fue actualizada.
Saludos
